### PR TITLE
add feature to enable on default disabled danger-local-https

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,22 @@ uniffi = { version = "0.28.0", features = ["build"] }
 
 [dev-dependencies]
 uniffi = { version = "0.28.0", features = ["bindgen-tests"] }
-bdk = { version = "0.29.0", features = ["all-keys", "use-esplora-ureq", "keys-bip39"] }
+bdk = { version = "0.29.0", features = [
+    "all-keys",
+    "use-esplora-ureq",
+    "keys-bip39",
+] }
 bitcoincore-rpc = "0.19.0"
 [dependencies]
 
-#payjoin = {version = "=0.18.0",  features = ["send", "receive", "base64", "v2", "io", "danger-local-https"] }
-payjoin={ git = "https://github.com/payjoin/rust-payjoin", rev = "941a6798f52f60d72061fc0a02b5b42146321453", features = ["send", "receive", "base64", "v2", "io", "danger-local-https"]}
+#payjoin = {version = "=0.18.0",  features = ["send", "receive", "base64", "v2", "io"] }
+payjoin = { git = "https://github.com/payjoin/rust-payjoin", rev = "941a6798f52f60d72061fc0a02b5b42146321453", features = [
+    "send",
+    "receive",
+    "base64",
+    "v2",
+    "io",
+] }
 uniffi = { version = "0.28.0" }
 thiserror = "1.0.47"
 ohttp = { version = "0.5.1" }
@@ -42,4 +52,5 @@ strip = true
 
 [features]
 default = ["uniffi/cli"]
-uniffi=[]
+uniffi = []
+enable-danger-local-https = ["payjoin/danger-local-https"]

--- a/src/io.rs
+++ b/src/io.rs
@@ -16,10 +16,11 @@ use crate::uri::Url;
 pub async fn fetch_ohttp_keys(
     ohttp_relay: Url,
     payjoin_directory: Url,
-    cert_der: Vec<u8>,
+    #[cfg(feature = "enable-danger-local-https")] cert_der: Vec<u8>,
 ) -> Result<OhttpKeys, PayjoinError> {
-    payjoin::io::fetch_ohttp_keys(ohttp_relay.into(), payjoin_directory.into(), cert_der)
-        .await
-        .map(|e| e.into())
-        .map_err(|e| e.into())
+    #[cfg(not(feature = "enable-danger-local-https"))]
+    let res = payjoin::io::fetch_ohttp_keys(ohttp_relay.into(), payjoin_directory.into());
+    #[cfg(feature = "enable-danger-local-https")]
+    let res = payjoin::io::fetch_ohttp_keys(ohttp_relay.into(), payjoin_directory.into(), cert_der);
+    res.await.map(|e| e.into()).map_err(|e| e.into())
 }


### PR DESCRIPTION
This PR removes the `danger-local-https` feature from the `payjoin` dependency, but makes it still possible to enable this when using `payjoin-ffi` through the `enable-danger-local-https` feature that is added.