### PR TITLE
Expose de/serialize for Sender, Receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.21.1]
+- Add `to_json` and `from_json` methods to `Sender` and `Receiver` UniFFI types. ([#39](https://github.com/LtbLightning/payjoin-ffi/pull/39))
+
 ## [0.21.0]
 This release updates the bindings libraries to `payjoin` version `0.21.0`.
 #### APIs changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,6 +2058,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "rustls 0.22.4",
+ "serde_json",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "base64 0.22.1",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_ffi"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = ["tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", rev = 
 hex = "0.4.3"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
 payjoin = { version = "0.21.0", features = ["send", "receive", "base64", "v2", "io"] }
+serde_json = "1.0.128"
 thiserror = "1.0.58"
 uniffi = { version = "0.28.0", optional = true }
 url = "2.5.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,9 @@ pub enum PayjoinError {
 
     #[error("{message}")]
     InputPairError { message: String },
+
+    #[error("{message}")]
+    SerdeJsonError { message: String },
 }
 
 macro_rules! impl_from_error {
@@ -99,6 +102,7 @@ impl_from_error! {
     OutputSubstitutionError => OutputSubstitutionError,
     InputContributionError => InputContributionError,
     PsbtInputError => InputPairError,
+    serde_json::Error => SerdeJsonError,
 }
 
 #[cfg(feature = "uniffi")]

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -97,6 +97,16 @@ impl Receiver {
     pub fn id(&self) -> String {
         <Self as Into<payjoin::receive::v2::Receiver>>::into(self.clone()).id().to_string()
     }
+
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        serde_json::to_string(&self.0).map_err(|e| e.into())
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, PayjoinError> {
+        let receiver = serde_json::from_str::<payjoin::receive::v2::Receiver>(json)
+            .map_err(<serde_json::Error as Into<PayjoinError>>::into)?;
+        Ok(receiver.into())
+    }
 }
 
 #[derive(Clone)]

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -87,6 +87,15 @@ impl Receiver {
     pub fn id(&self) -> String {
         self.0.id()
     }
+
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        self.0.to_json()
+    }
+
+    #[uniffi::constructor]
+    pub fn from_json(json: &str) -> Result<Self, PayjoinError> {
+        super::Receiver::from_json(json).map(Into::into)
+    }
 }
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -124,6 +124,16 @@ impl Sender {
             Err(e) => Err(e.into()),
         }
     }
+
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        serde_json::to_string(&self.0).map_err(|e| e.into())
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, PayjoinError> {
+        let sender = serde_json::from_str::<payjoin::send::Sender>(json)
+            .map_err(<serde_json::Error as Into<PayjoinError>>::into)?;
+        Ok(sender.into())
+    }
 }
 
 /// Data required for validation of response.

--- a/src/send/uni.rs
+++ b/src/send/uni.rs
@@ -125,6 +125,15 @@ impl Sender {
             Err(e) => Err(e),
         }
     }
+
+    pub fn to_json(&self) -> Result<String, PayjoinError> {
+        self.0.to_json()
+    }
+
+    #[uniffi::constructor]
+    pub fn from_json(json: &str) -> Result<Self, PayjoinError> {
+        super::Sender::from_json(json).map(Into::into)
+    }
 }
 
 #[derive(uniffi::Object)]


### PR DESCRIPTION
These structs need to be serialized and deserialized in order to be persisted in a downstream database.

We use json to do this only because that decision was made in payjoin-cli. A binary encoding could be used as well, but that bikeshed is to be built at a later date.