### PR TITLE
Expose PjUri pj_endpoint() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.21.2]
+- Add `pj_endpoint` method to `PjUri` types. ([#40](https://github.com/LtbLightning/payjoin-ffi/pull/40))
+
 ## [0.21.1]
 - Add `to_json` and `from_json` methods to `Sender` and `Receiver` UniFFI types. ([#39](https://github.com/LtbLightning/payjoin-ffi/pull/39))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "base64 0.22.1",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_ffi"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = ["tests"]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -86,6 +86,11 @@ impl PjUri {
     pub fn amount_sats(&self) -> Option<u64> {
         self.0.clone().amount.map(|e| e.to_sat())
     }
+
+    pub fn pj_endpoint(&self) -> String {
+        self.0.extras.endpoint().to_string()
+    }
+
     pub fn as_string(&self) -> String {
         self.0.clone().to_string()
     }


### PR DESCRIPTION
- Add `pj_endpoint` method to `PjUri` types.
    `pj_endpoint` is used as the `Sender` id for persistent storage.
- Bump payjoin-ffi 0.21.2

This has been smoke tested from bullbitcoin-mobile @spacebear21 