### PR TITLE
Depend on payjoin-0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.22.0]
+- Update `payjoin` to `0.22.0`. (Serialize reply_key with Sender [#41](https://github.com/LtbLightning/payjoin-ffi/pull/41))
+
 ## [0.21.2]
 - Add `pj_endpoint` method to `PjUri` types. ([#40](https://github.com/LtbLightning/payjoin-ffi/pull/40))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "bdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,9 +2000,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "payjoin"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27948a9d8f5569cbce7d3c73e5c81058e4c918ef9b9795e08a8d17cdc4a73b7a"
+checksum = "68fa76c2e9808651a9179c577f5337f4223ec929457bb0c3ff744ffea884890b"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.5",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "payjoin-directory"
 version = "0.0.1"
-source = "git+https://github.com/payjoin/rust-payjoin?rev=a1fbac5#a1fbac52447ac99fb2f73831d7159b8e95785b47"
+source = "git+https://github.com/payjoin/rust-payjoin?rev=f202098#f202098de40abfbcc1768ba3b6f4a16adda37c3e"
 dependencies = [
  "anyhow",
  "bhttp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_ffi"
-version = "0.21.2"
+version = "0.22.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = ["tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.22.1"
 bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", rev = "4cd8e644dbf4e001d71d5fffb232480fa5ff2246" }
 hex = "0.4.3"
 ohttp = { package = "bitcoin-ohttp", version = "0.6.0" }
-payjoin = { version = "0.21.0", features = ["send", "receive", "base64", "v2", "io"] }
+payjoin = { version = "0.22.0", features = ["send", "receive", "base64", "v2", "io"] }
 serde_json = "1.0.128"
 thiserror = "1.0.58"
 uniffi = { version = "0.28.0", optional = true }
@@ -37,7 +37,7 @@ bitcoind = { version = "0.36.0", features = ["0_21_2"] }
 bitcoincore-rpc = "0.19.0"
 http = "1"
 ohttp-relay = "0.0.8"
-payjoin-directory = { git = "https://github.com/payjoin/rust-payjoin", rev = "a1fbac5", features = ["_danger-local-https"] }
+payjoin-directory = { git = "https://github.com/payjoin/rust-payjoin", rev = "f202098", features = ["_danger-local-https"] }
 rcgen = { version = "0.11" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rustls = "0.22.2"


### PR DESCRIPTION
There was a problem where persisted Senders (https://github.com/payjoin/rust-payjoin/pull/443) would resume in such a way that they would never find an async receiver's payjoin proposal.

This change fixes that, but should wait until we release payjoin 0.22

