### PR TITLE
expose label and messge params on uri

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -34,6 +34,12 @@ impl Uri {
     pub fn amount_sats(&self) -> Option<u64> {
         self.0.amount.map(|x| x.to_sat())
     }
+    pub fn label(&self) -> Option<String> {
+        self.0.label.clone().and_then(|x| String::try_from(x).ok())
+    }
+    pub fn message(&self) -> Option<String> {
+        self.0.message.clone().and_then(|x| String::try_from(x).ok())
+    }
     #[cfg(not(feature = "uniffi"))]
     pub fn check_pj_supported(&self) -> Result<PjUri, PayjoinError> {
         match self.0.clone().check_pj_supported() {


### PR DESCRIPTION
addresses https://github.com/LtbLightning/payjoin-flutter/issues/48

this update is needed for desired modifications to bullbitcoin app https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/491

(after merge, payjoin-flutter must also be updated to expose)

Further details:
The main goal here is to get bull-bitcoin to be bip21 spec compliant. 
The plan is to do so by leveraging rust implementation. 
This is something that's used in and mostly exposed by payjoin already, we simply need to expose the label and message params and then the Uri type fully exposes desired bip21 functionality. 
This means that any app that uses payjoin-ffi will have a spec compliant bip21 parser included.
If you look at the proposed pr on bb you can see this enables significant improvements: namely deleting imperfectly implemented bip21 logic, also avoiding some hacky additional logic.