### PR TITLE
Bump payjoin-ffi-0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.22.1]
+- Expose label and messge params on Uri. ([#44](https://github.com/LtbLightning/payjoin-ffi/pull/44))
+
 ## [0.22.0]
 - Update `payjoin` to `0.22.0`. (Serialize reply_key with Sender [#41](https://github.com/LtbLightning/payjoin-ffi/pull/41))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin_ffi"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "base64 0.22.1",
  "bdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin_ffi"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = ["tests"]


### PR DESCRIPTION
Updates since last release:
- The Uri type now exposes label and message params so it can be used as a fully functional bip21 uri parser
- Bump version