### PR TITLE
Rename BIP178 -> BIP-78

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Payjoin Language Bindings
 
-Welcome! This repository creates libraries for various programming languages, all using the Rust-based [Payjoin](https://github.com/payjoin/rust-payjoin) as the core implementation of BIP178, sourced from the [Payjoin Dev Kit](https://payjoindevkit.org/).
+Welcome! This repository creates libraries for various programming languages, all using the Rust-based [Payjoin](https://github.com/payjoin/rust-payjoin) as the core implementation of BIP-78, sourced from the [Payjoin Dev Kit](https://payjoindevkit.org/).
 
 Our mission is to provide developers with cross-language libraries that seamlessly integrate with different platform languages. By offering support for multiple languages, we aim to enhance the accessibility and usability of Payjoin, empowering developers to incorporate this privacy-enhancing feature into their applications, no matter their preferred programming language.
 
-With a commitment to collaboration and interoperability, this repository strives to foster a more inclusive and diverse ecosystem around Payjoin and BIP178, contributing to the wider adoption of privacy-focused practices within the Bitcoin community. Join us in our mission to build a more private and secure future for Bitcoin transactions through Payjoin and BIP178!
+With a commitment to collaboration and interoperability, this repository strives to foster a more inclusive and diverse ecosystem around Payjoin and BIP-78, contributing to the wider adoption of privacy-focused practices within the Bitcoin community. Join us in our mission to build a more private and secure future for Bitcoin transactions through Payjoin and BIP-78!
 
 **Current Status:**
 This project is in the pre-alpha stage and currently in the design phase. The first language bindings available will be for Python, followed by Swift and Kotlin. Our ultimate goal is to provide Payjoin implementations for Android, iOS, Java, React, Python Native, Flutter, C#, and Golang.


### PR DESCRIPTION
The README repeatedly mentions [BIP178](https://github.com/bitcoin/bips/blob/master/bip-0178.mediawiki) when intending to mention BIP-78, this is just a simple find-and-replace for all occurrences of this mistake.

If/since bindings are compatible with Payjoin V2, this should probably be updated to include mention of BIP-77 as well