### PR TITLE
Move bitcoinlib dependency to requirments.txt

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -19,8 +19,7 @@ git clone https://github.com/LtbLightning/payjoin-ffi.git
 cd python
 
 # Install dependencies
-pip install --requirement requirements.txt
-pip install python-bitcoinlib
+pip install --requirement requirements.txt --requirement requirements-dev.txt
 
 # Build the wheel
 python setup.py bdist_wheel --verbose
@@ -45,8 +44,7 @@ git clone https://github.com/LtbLightning/payjoin-ffi.git
 cd python
 
 # Install dependencies
-pip install --requirement requirements.txt
-pip install python-bitcoinlib
+pip install --requirement requirements.txt --requirement requirements-dev.txt
 
 # Build the wheel
 python setup.py bdist_wheel --verbose

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,0 +1,1 @@
+python-bitcoinlib==0.12.2


### PR DESCRIPTION
Just found it odd this one dependency lived outside requirments.txt. I also pinned to a specific version. Any reason we want to explicitly install this one? 