### PR TITLE
Fix missing `uniffi` in generate bindings script

### DIFF
--- a/python/scripts/generate_linux.sh
+++ b/python/scripts/generate_linux.sh
@@ -7,7 +7,7 @@ LINUX_TARGET=x86_64-unknown-linux-gnu
 
 echo "Generating payjoin_ffi.py..."
 cd ../
-cargo run --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
+cargo run --features uniffi --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
 
 
 echo "Generating native binaries..."

--- a/python/scripts/generate_macos.sh
+++ b/python/scripts/generate_macos.sh
@@ -7,7 +7,7 @@ LIBNAME=libpayjoin_ffi.dylib
 
 echo "Generating payjoin_ffi.py..."
 cd ../
-cargo run --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
+cargo run --features uniffi --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
 
 
 echo "Generating native binaries..."

--- a/python/scripts/generate_windows.sh
+++ b/python/scripts/generate_windows.sh
@@ -6,7 +6,7 @@ LIBNAME=payjoin_ffi.dll
 WINDOWS_TARGET=x86_64-pc-windows-gnu
 echo "Generating payjoin_ffi.py..."
 cd ../
-cargo run --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
+cargo run --features uniffi --bin uniffi-bindgen generate src/payjoin_ffi.udl --language python --out-dir python/src/payjoin/
 
 
 echo "Generating native binaries..."


### PR DESCRIPTION
All of the generate python bindings scripts were missing `--features uniffi`. These scripts would generate the dynamic library files but would silently fail to update the `payjoin_ffi.py` file b/c the .udl file is empty without the `uniffi` feature flag.