### PR TITLE
Install yapf@0.43.0 as a python dev-dependency

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,2 +1,4 @@
 python-bitcoinlib==0.12.2
 toml==0.10.2
+yapf==0.43.0
+


### PR DESCRIPTION
During ffi bindings genration yapf is already used to lint the generated files. Without yapf a warning is generated and the files are unlinted.

```
Warning: Unable to auto-format bitcoin.py using yapf: Os { code: 2,
kind: NotFound, message: "No such file or directory" }
Warning: Unable to auto-format payjoin_ffi.py using yapf: Os { code: 2,
kind: NotFound, message: "No such file or directory" }
```