### PR TITLE
Replyable errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1846,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -1936,7 +1936,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "payjoin"
 version = "0.22.0"
-source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#59f2a34149f5b7d652ee3920aa8b1461279d4f82"
+source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#53a3187887e82925fc3f999fb73ab08caf8d1832"
 dependencies = [
  "bhttp",
  "bitcoin 0.32.5",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "payjoin-directory"
 version = "0.0.1"
-source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#59f2a34149f5b7d652ee3920aa8b1461279d4f82"
+source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#53a3187887e82925fc3f999fb73ab08caf8d1832"
 dependencies = [
  "anyhow",
  "bhttp",
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "payjoin-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#59f2a34149f5b7d652ee3920aa8b1461279d4f82"
+source = "git+https://github.com/payjoin/rust-payjoin.git?branch=bindings-0.23#53a3187887e82925fc3f999fb73ab08caf8d1832"
 dependencies = [
  "bitcoin 0.32.5",
  "bitcoin-ohttp",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,4 @@
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error de/serializing JSON object: {msg}")]
+#[derive(Debug, thiserror::Error)]
+#[error("Error de/serializing JSON object: {0}")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct SerdeJsonError {
-    msg: String,
-}
-impl From<serde_json::Error> for SerdeJsonError {
-    fn from(value: serde_json::Error) -> Self {
-        SerdeJsonError { msg: format!("{:?}", value) }
-    }
-}
+pub struct SerdeJsonError(#[from] serde_json::Error);

--- a/src/receive/error.rs
+++ b/src/receive/error.rs
@@ -42,6 +42,31 @@ impl From<receive::Error> for Error {
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct ReplyableError(#[from] receive::ReplyableError);
 
+/// The standard format for errors that can be replied as JSON.
+///
+/// The JSON output includes the following fields:
+/// ```json
+/// {
+///     "errorCode": "specific-error-code",
+///     "message": "Human readable error message"
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct JsonReply(receive::JsonReply);
+
+impl From<JsonReply> for receive::JsonReply {
+    fn from(value: JsonReply) -> Self {
+        value.0
+    }
+}
+
+impl From<ReplyableError> for JsonReply {
+    fn from(value: ReplyableError) -> Self {
+        Self(value.0.into())
+    }
+}
+
 /// Error arising due to the specific receiver implementation
 ///
 /// e.g. database errors, network failures, wallet errors

--- a/src/receive/error.rs
+++ b/src/receive/error.rs
@@ -67,12 +67,6 @@ impl From<receive::ReplyableError> for ReplyableError {
     }
 }
 
-impl From<payjoin::bitcoin::address::ParseError> for Error {
-    fn from(value: payjoin::bitcoin::address::ParseError) -> Self {
-        Error::V2 { msg: value.to_string() }
-    }
-}
-
 impl From<IntoUrlError> for Error {
     fn from(value: IntoUrlError) -> Self {
         Error::V2 { msg: value.to_string() }

--- a/src/receive/error.rs
+++ b/src/receive/error.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use payjoin::{receive, IntoUrlError};
+use payjoin::receive;
 
 /// The top-level error type for the payjoin receiver
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
@@ -64,12 +64,6 @@ impl From<receive::ReplyableError> for ReplyableError {
                 }))
             }
         }
-    }
-}
-
-impl From<IntoUrlError> for Error {
-    fn from(value: IntoUrlError) -> Self {
-        Error::V2 { msg: value.to_string() }
     }
 }
 

--- a/src/receive/error.rs
+++ b/src/receive/error.rs
@@ -3,128 +3,85 @@ use std::sync::Arc;
 use payjoin::receive;
 
 /// The top-level error type for the payjoin receiver
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
 pub enum Error {
     /// Errors that can be replied to the sender
     #[error("Replyable error: {0}")]
-    ReplyToSender(ReplyableError),
+    ReplyToSender(Arc<ReplyableError>),
     /// V2-specific errors that are infeasable to reply to the sender
-    #[error("Unreplyable error: {msg}")]
-    V2 { msg: String },
+    #[error("Unreplyable error: {0}")]
+    V2(Arc<SessionError>),
     /// Catch-all for unhandled error variants
     #[error("An unexpected error occurred")]
     Unexpected,
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
-pub enum ReplyableError {
-    /// Error arising from validation of the original PSBT payload
-    #[error("Error while validating original PSBT payload: {msg}")]
-    Payload { msg: String },
-    /// Protocol-specific errors for BIP-78 v1 requests (e.g. HTTP request validation, parameter checks)
-    #[error("Error while validating V1 request: {msg}")]
-    V1 { msg: String },
-    /// Error arising due to the specific receiver implementation
-    ///
-    /// e.g. database errors, network failures, wallet errors
-    #[error(transparent)]
-    Implementation(Arc<ImplementationError>),
-}
-
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error occurred in receiver implementation: {msg}")]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct ImplementationError {
-    msg: String,
-}
-
 impl From<receive::Error> for Error {
     fn from(value: receive::Error) -> Self {
         match value {
-            receive::Error::ReplyToSender(e) => Error::ReplyToSender(e.into()),
-            receive::Error::V2(_) => Error::V2 { msg: value.to_string() },
+            receive::Error::ReplyToSender(e) => Error::ReplyToSender(Arc::new(ReplyableError(e))),
+            receive::Error::V2(e) => Error::V2(Arc::new(SessionError(e))),
             _ => Error::Unexpected,
         }
     }
 }
 
-impl From<receive::ReplyableError> for ReplyableError {
-    fn from(value: receive::ReplyableError) -> Self {
-        match value {
-            receive::ReplyableError::Payload(_) => {
-                ReplyableError::Payload { msg: value.to_string() }
-            }
-            receive::ReplyableError::V1(_) => ReplyableError::V1 { msg: value.to_string() },
-            receive::ReplyableError::Implementation(_) => {
-                ReplyableError::Implementation(Arc::new(ImplementationError {
-                    msg: value.to_string(),
-                }))
-            }
-        }
-    }
-}
-
-/// Error that may occur when output substitution fails.
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Output substition error: {msg}")]
+/// The replyable error type for the payjoin receiver, representing failures need to be
+/// returned to the sender.
+///
+/// The error handling is designed to:
+/// 1. Provide structured error responses for protocol-level failures
+/// 2. Hide implementation details of external errors for security
+/// 3. Support proper error propagation through the receiver stack
+/// 4. Provide errors according to BIP-78 JSON error specifications for return
+///    after conversion into [`JsonReply`]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct OutputSubstitutionError {
-    msg: String,
-}
+pub struct ReplyableError(#[from] receive::ReplyableError);
 
-impl From<receive::OutputSubstitutionError> for OutputSubstitutionError {
-    fn from(value: receive::OutputSubstitutionError) -> Self {
-        OutputSubstitutionError { msg: value.to_string() }
-    }
-}
-
-/// Error that may occur when coin selection fails.
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error occurred during coin selection: {msg}")]
+/// Error arising due to the specific receiver implementation
+///
+/// e.g. database errors, network failures, wallet errors
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct SelectionError {
-    msg: String,
-}
-
-impl From<receive::SelectionError> for SelectionError {
-    fn from(value: receive::SelectionError) -> Self {
-        SelectionError { msg: value.to_string() }
-    }
-}
-
-/// Error that may occur when input contribution fails.
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Input contribution error: {msg}")]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct InputContributionError {
-    msg: String,
-}
-
-impl From<receive::InputContributionError> for InputContributionError {
-    fn from(value: receive::InputContributionError) -> Self {
-        InputContributionError { msg: value.to_string() }
-    }
-}
-
-/// Error validating a PSBT Input
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error validating PSBT input: {msg}")]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct PsbtInputError {
-    msg: String,
-}
-
-impl From<receive::PsbtInputError> for PsbtInputError {
-    fn from(value: receive::PsbtInputError) -> Self {
-        PsbtInputError { msg: value.to_string() }
-    }
-}
+pub struct ImplementationError(#[from] receive::ImplementationError);
 
 impl From<String> for ImplementationError {
-    fn from(msg: String) -> Self {
-        ImplementationError { msg }
+    fn from(value: String) -> Self {
+        Self(value.into())
     }
 }
+
+/// Error that may occur during a v2 session typestate change
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct SessionError(#[from] receive::v2::SessionError);
+
+/// Error that may occur when output substitution fails.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct OutputSubstitutionError(#[from] receive::OutputSubstitutionError);
+
+/// Error that may occur when coin selection fails.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct SelectionError(#[from] receive::SelectionError);
+
+/// Error that may occur when input contribution fails.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct InputContributionError(#[from] receive::InputContributionError);
+
+/// Error validating a PSBT Input
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct PsbtInputError(#[from] receive::PsbtInputError);

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -8,7 +8,7 @@ pub use error::{
 use payjoin::bitcoin::psbt::Psbt;
 use payjoin::bitcoin::FeeRate;
 
-use crate::bitcoin_ffi::{Network, OutPoint, Script, TxOut};
+use crate::bitcoin_ffi::{Address, OutPoint, Script, TxOut};
 pub use crate::error::SerdeJsonError;
 use crate::ohttp::OhttpKeys;
 use crate::{ClientResponse, Request};
@@ -36,7 +36,6 @@ impl Receiver {
     ///
     /// # Parameters
     /// - `address`: The Bitcoin address for the payjoin session.
-    /// - `network`: The network to use for address verification.
     /// - `directory`: The URL of the store-and-forward payjoin directory.
     /// - `ohttp_keys`: The OHTTP keys used for encrypting and decrypting HTTP requests and responses.
     /// - `ohttp_relay`: The URL of the OHTTP relay, used to keep client IP address confidential.
@@ -48,16 +47,13 @@ impl Receiver {
     /// # References
     /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/pull/1483)
     pub fn new(
-        address: String,
-        network: Network,
+        address: Address,
         directory: String,
         ohttp_keys: OhttpKeys,
         expire_after: Option<u64>,
     ) -> Result<Self, Error> {
-        let address = payjoin::bitcoin::Address::from_str(address.as_str())?
-            .require_network(network.into())?;
         payjoin::receive::v2::Receiver::new(
-            address,
+            address.into(),
             directory,
             ohttp_keys.into(),
             expire_after.map(Duration::from_secs),

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -11,6 +11,7 @@ use payjoin::bitcoin::FeeRate;
 use crate::bitcoin_ffi::{Address, OutPoint, Script, TxOut};
 pub use crate::error::SerdeJsonError;
 use crate::ohttp::OhttpKeys;
+use crate::uri::error::IntoUrlError;
 use crate::{ClientResponse, Request};
 
 pub mod error;
@@ -51,7 +52,7 @@ impl Receiver {
         directory: String,
         ohttp_keys: OhttpKeys,
         expire_after: Option<u64>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, IntoUrlError> {
         payjoin::receive::v2::Receiver::new(
             address.into(),
             directory,

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::InputPair;
-use crate::bitcoin_ffi::{Network, OutPoint, Script, TxOut};
+use crate::bitcoin_ffi::{Address, OutPoint, Script, TxOut};
 pub use crate::receive::{
     Error, ImplementationError, InputContributionError, OutputSubstitutionError, ReplyableError,
     SelectionError, SerdeJsonError,
@@ -29,7 +29,6 @@ impl Receiver {
     ///
     /// # Parameters
     /// - `address`: The Bitcoin address for the payjoin session.
-    /// - `network`: The network to use for address verification.
     /// - `directory`: The URL of the store-and-forward payjoin directory.
     /// - `ohttp_keys`: The OHTTP keys used for encrypting and decrypting HTTP requests and responses.
     /// - `ohttp_relay`: The URL of the OHTTP relay, used to keep client IP address confidential.
@@ -42,13 +41,12 @@ impl Receiver {
     /// - [BIP 77: Payjoin Version 2: Serverless Payjoin](https://github.com/bitcoin/bips/pull/1483)
     #[uniffi::constructor]
     pub fn new(
-        address: String,
-        network: Network,
+        address: Arc<Address>,
         directory: String,
         ohttp_keys: Arc<OhttpKeys>,
         expire_after: Option<u64>,
     ) -> Result<Self, Error> {
-        super::Receiver::new(address, network, directory, (*ohttp_keys).clone(), expire_after)
+        super::Receiver::new((*address).clone(), directory, (*ohttp_keys).clone(), expire_after)
             .map(Into::into)
     }
 

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -6,6 +6,7 @@ pub use crate::receive::{
     Error, ImplementationError, InputContributionError, OutputSubstitutionError, ReplyableError,
     SelectionError, SerdeJsonError,
 };
+use crate::uri::error::IntoUrlError;
 use crate::{ClientResponse, OhttpKeys, Request};
 
 #[derive(Clone, Debug, uniffi::Object)]
@@ -45,7 +46,7 @@ impl Receiver {
         directory: String,
         ohttp_keys: Arc<OhttpKeys>,
         expire_after: Option<u64>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, IntoUrlError> {
         super::Receiver::new((*address).clone(), directory, (*ohttp_keys).clone(), expire_after)
             .map(Into::into)
     }

--- a/src/uri/error.rs
+++ b/src/uri/error.rs
@@ -36,3 +36,16 @@ impl From<payjoin::ParseError> for UrlParseError {
         UrlParseError { msg: format!("{:?}", value) }
     }
 }
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("Error converting to URL: {msg}")]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct IntoUrlError {
+    msg: String,
+}
+
+impl From<payjoin::IntoUrlError> for IntoUrlError {
+    fn from(value: payjoin::IntoUrlError) -> Self {
+        IntoUrlError { msg: format!("{:?}", value) }
+    }
+}

--- a/src/uri/error.rs
+++ b/src/uri/error.rs
@@ -24,28 +24,12 @@ impl From<String> for PjNotSupported {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error parsing URL: {msg}")]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct UrlParseError {
-    msg: String,
-}
+pub struct UrlParseError(#[from] payjoin::ParseError);
 
-impl From<payjoin::ParseError> for UrlParseError {
-    fn from(value: payjoin::ParseError) -> Self {
-        UrlParseError { msg: format!("{:?}", value) }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
-#[error("Error converting to URL: {msg}")]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
-pub struct IntoUrlError {
-    msg: String,
-}
-
-impl From<payjoin::IntoUrlError> for IntoUrlError {
-    fn from(value: payjoin::IntoUrlError) -> Self {
-        IntoUrlError { msg: format!("{:?}", value) }
-    }
-}
+pub struct IntoUrlError(#[from] payjoin::IntoUrlError);

--- a/tests/bdk_integration_test.rs
+++ b/tests/bdk_integration_test.rs
@@ -222,7 +222,7 @@ mod v2 {
     use std::sync::Arc;
 
     use bdk::wallet::AddressIndex;
-    use bitcoin_ffi::Network;
+    use bitcoin_ffi::{Address, Network};
     use payjoin_ffi::receive::{PayjoinProposal, Receiver, UncheckedProposal};
     use payjoin_ffi::send::SenderBuilder;
     use payjoin_ffi::uri::Uri;
@@ -254,8 +254,7 @@ mod v2 {
 
             let address = receiver.get_address(AddressIndex::New);
             let session = Receiver::new(
-                address.to_string(),
-                Network::Regtest,
+                Address::new(address.to_string(), Network::Regtest).unwrap(),
                 directory.to_string(),
                 OhttpKeys(ohttp_keys),
                 None,


### PR DESCRIPTION
This PR addresses #59, #68, #69, and to a lesser extent #70.

I strove to replace all the opaque error types that were previously `struct { msg: String }` into the much cleaner and less boilerplate `struct WrapperError(#[from] payjoin::InnerError)` with `#[error(transparent)]`. There are a few stragglers that I'd like to address but don't have a clear way forward yet, so I highlighted those in PR comments.

