### PR TITLE
Update payjoin URI tests to use Url.parse

### DIFF
--- a/python/test/payjoin_unit_test.py
+++ b/python/test/payjoin_unit_test.py
@@ -3,22 +3,18 @@ import payjoin as payjoin
 
 
 class TestURIs(unittest.TestCase):
-    @unittest.skip("Payjoin.Uri FFI bindings are currently not working")
     def test_todo_url_encoded(self):
         uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=https://example.com?ciao"
-        self.assertTrue(payjoin.Uri.from_str(uri), "pj url should be url encoded")
+        self.assertTrue(payjoin.Url.parse(uri), "pj url should be url encoded")
 
-    @unittest.skip("Payjoin.Uri FFI bindings are currently not working")
     def test_valid_url(self):
         uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=https://example.com?ciao"
-        self.assertTrue(payjoin.Uri.from_str(uri), "pj is not a valid url")
+        self.assertTrue(payjoin.Url.parse(uri), "pj is not a valid url")
 
-    @unittest.skip("Payjoin.Uri FFI bindings are currently not working")
     def test_missing_amount(self):
         uri = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://testnet.demo.btcpayserver.org/BTC/pj"
-        self.assertTrue(payjoin.Uri.from_str(uri), "missing amount should be ok")
+        self.assertTrue(payjoin.Url.parse(uri), "missing amount should be ok")
 
-    @unittest.skip("Payjoin.Uri FFI bindings are currently not working")
     def test_valid_uris(self):
         https = "https://example.com"
         onion = "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion"
@@ -31,10 +27,9 @@ class TestURIs(unittest.TestCase):
             for pj in [https, onion]:
                 uri = f"{address}?amount=1&pj={pj}"
                 try:
-                    payjoin.Uri.from_str(uri)
+                    payjoin.Url.parse(uri)
                 except Exception as e:
                     self.fail(f"Failed to create a valid Uri for {uri}. Error: {e}")
-                    # recieve module
 
 
 class ScriptOwnershipCallback(payjoin.IsScriptOwned):


### PR DESCRIPTION
Replaces deprecated or broken `payjoin.Uri.from_str` calls with `payjoin.Url.parse` and re-enables the previously skipped unit tests.