### PR TITLE
Drop pub from wrapped OhttpKeys field

### DIFF
--- a/src/ohttp.rs
+++ b/src/ohttp.rs
@@ -22,7 +22,7 @@ impl From<OhttpKeys> for payjoin::OhttpKeys {
 }
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 #[derive(Debug, Clone)]
-pub struct OhttpKeys(pub payjoin::OhttpKeys);
+pub struct OhttpKeys(payjoin::OhttpKeys);
 
 #[cfg_attr(feature = "uniffi", uniffi::export)]
 impl OhttpKeys {

--- a/tests/bdk_integration_test.rs
+++ b/tests/bdk_integration_test.rs
@@ -226,7 +226,7 @@ mod v2 {
     use payjoin_ffi::receive::{PayjoinProposal, Receiver, UncheckedProposal};
     use payjoin_ffi::send::SenderBuilder;
     use payjoin_ffi::uri::Uri;
-    use payjoin_ffi::{OhttpKeys, Request};
+    use payjoin_ffi::Request;
     use payjoin_test_utils::TestServices;
 
     use super::*;
@@ -250,13 +250,18 @@ mod v2 {
             let agent = services.http_agent();
             let directory = services.directory_url();
             services.wait_for_services_ready().await?;
-            let ohttp_keys = services.fetch_ohttp_keys().await?;
+            let ohttp_keys = payjoin_ffi::io::fetch_ohttp_keys_with_cert(
+                services.ohttp_relay_url().as_str(),
+                directory.as_str(),
+                services.cert(),
+            )
+            .await?;
 
             let address = receiver.get_address(AddressIndex::New);
             let session = Receiver::new(
                 Address::new(address.to_string(), Network::Regtest).unwrap(),
                 directory.to_string(),
-                OhttpKeys(ohttp_keys),
+                ohttp_keys,
                 None,
             )?;
             let ohttp_relay = services.ohttp_relay_url();


### PR DESCRIPTION
Remove payjoin::OhttpKeys from the public API, otherwise why even wrap?