### PR TITLE
e2e persistence python unit tests

### DIFF
--- a/python/test/payjoin_unit_test.py
+++ b/python/test/payjoin_unit_test.py
@@ -1,5 +1,6 @@
 import unittest
 import payjoin as payjoin
+import payjoin.bitcoin
 
 class TestURIs(unittest.TestCase):
     def test_todo_url_encoded(self):
@@ -107,6 +108,69 @@ class TestReceiveModule(unittest.TestCase):
         except Exception as e:
             self.fail(f"test_unchecked_proposal_unlocks_after_checks exception: {e}")
 
+class InMemoryReceiverPersister(payjoin.payjoin_ffi.ReceiverPersister):
+    def __init__(self):
+        self.receivers = {}
 
+    def save(self, receiver: payjoin.Receiver) -> payjoin.ReceiverToken:
+        self.receivers[str(receiver.key())] = receiver.to_json()
+
+        return receiver.key()
+
+    def load(self, token: payjoin.ReceiverToken) -> payjoin.Receiver:
+        token = str(token)
+        if token not in self.receivers.keys():
+            raise ValueError(f"Token not found: {token}")
+        return payjoin.Receiver.from_json(self.receivers[token])
+
+ 
+class TestRecieverPersistence(unittest.TestCase):
+    def test_receiver_persistence(self):
+        persister = InMemoryReceiverPersister()
+        address = payjoin.bitcoin.Address("tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4", payjoin.bitcoin.Network.SIGNET)
+        new_receiver = payjoin.NewReceiver(
+            address, 
+            "https://example.com", 
+            payjoin.OhttpKeys.from_string("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"), 
+            None
+        )
+        token = new_receiver.persist(persister)
+        payjoin.Receiver.load(token, persister)
+
+class InMemorySenderPersister(payjoin.payjoin_ffi.SenderPersister):
+    def __init__(self):
+        self.senders = {}
+
+    def save(self, sender: payjoin.Sender) -> payjoin.SenderToken:
+        self.senders[str(sender.key())] = sender.to_json()
+        return sender.key()
+    
+    def load(self, token: payjoin.SenderToken) -> payjoin.Sender:
+        token = str(token)
+        if token not in self.senders.keys():
+            raise ValueError(f"Token not found: {token}")
+        return payjoin.Sender.from_json(self.senders[token])
+    
+class TestSenderPersistence(unittest.TestCase):
+    def test_sender_persistence(self):
+        # Create a receiver to just get the pj uri
+        persister = InMemoryReceiverPersister()
+        address = payjoin.bitcoin.Address("2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK", payjoin.bitcoin.Network.TESTNET)
+        new_receiver = payjoin.NewReceiver(
+            address, 
+            "https://example.com", 
+            payjoin.OhttpKeys.from_string("OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"), 
+            None
+        )
+        token = new_receiver.persist(persister)
+        reciever = payjoin.Receiver.load(token, persister)
+        uri = reciever.pj_uri()
+
+        persister = InMemorySenderPersister()
+        psbt = "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA="
+        new_sender = payjoin.SenderBuilder(psbt, uri).build_recommended(1000)
+        token = new_sender.persist(persister)
+        payjoin.Sender.load(token, persister)
+            
 if __name__ == "__main__":
     unittest.main()

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,3 +2,17 @@
 #[error("Error de/serializing JSON object: {0}")]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct SerdeJsonError(#[from] serde_json::Error);
+
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum PersistenceError {
+    #[error("Internal error: {0}")]
+    InternalError(String),
+}
+
+#[cfg(feature = "uniffi")]
+impl From<uniffi::UnexpectedUniFFICallbackError> for PersistenceError {
+    fn from(_: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::InternalError("Unexpected Uniffi callback error".to_string())
+    }
+}

--- a/src/ohttp.rs
+++ b/src/ohttp.rs
@@ -12,6 +12,11 @@ pub mod error {
             OhttpError { message: format!("{value:?}") }
         }
     }
+    impl From<String> for OhttpError {
+        fn from(value: String) -> Self {
+            OhttpError { message: value }
+        }
+    }
 }
 
 impl From<payjoin::OhttpKeys> for OhttpKeys {
@@ -35,8 +40,17 @@ impl OhttpKeys {
     pub fn decode(bytes: Vec<u8>) -> Result<Self, OhttpError> {
         payjoin::OhttpKeys::decode(bytes.as_slice()).map(Into::into).map_err(Into::into)
     }
+
+    /// Create an OHTTP KeyConfig from a string
+    #[cfg_attr(feature = "uniffi", uniffi::constructor)]
+    pub fn from_string(s: String) -> Result<Self, OhttpError> {
+        let res = payjoin::OhttpKeys::from_str(s.as_str())
+            .map_err(|e| OhttpError::from(e.to_string()))?;
+        Ok(Self(res))
+    }
 }
 
+use std::str::FromStr;
 use std::sync::Mutex;
 
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::InputPair;
 use crate::bitcoin_ffi::{Address, OutPoint, Script, TxOut};
+use crate::error::PersistenceError;
 pub use crate::receive::{
     Error, ImplementationError, InputContributionError, JsonReply, OutputSubstitutionError,
     ReplyableError, SelectionError, SerdeJsonError, SessionError,
@@ -61,17 +62,30 @@ impl NewReceiver {
 }
 
 #[derive(Clone, Debug, uniffi::Object)]
-pub struct ReceiverToken(#[allow(dead_code)] payjoin::receive::v2::ReceiverToken);
+#[uniffi::export(Display)]
+pub struct ReceiverToken(#[allow(dead_code)] Arc<payjoin::receive::v2::ReceiverToken>);
+
+impl std::fmt::Display for ReceiverToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl From<payjoin::receive::v2::Receiver> for ReceiverToken {
     fn from(value: payjoin::receive::v2::Receiver) -> Self {
-        ReceiverToken(value.into())
+        ReceiverToken(Arc::new(value.into()))
     }
 }
 
 impl From<payjoin::receive::v2::ReceiverToken> for ReceiverToken {
     fn from(value: payjoin::receive::v2::ReceiverToken) -> Self {
-        ReceiverToken(value)
+        ReceiverToken(Arc::new(value))
+    }
+}
+
+impl From<ReceiverToken> for payjoin::receive::v2::ReceiverToken {
+    fn from(value: ReceiverToken) -> Self {
+        (*value.0).clone()
     }
 }
 
@@ -98,7 +112,7 @@ impl Receiver {
         token: Arc<ReceiverToken>,
         persister: Arc<dyn ReceiverPersister>,
     ) -> Result<Self, ImplementationError> {
-        Ok(super::Receiver::from(persister.load(token).unwrap()).into())
+        Ok(super::Receiver::from((*persister.load(token).unwrap()).clone()).into())
     }
 
     /// The contents of the `&pj=` query parameter including the base64url-encoded public key receiver subdirectory.
@@ -482,10 +496,10 @@ impl PayjoinProposal {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(with_foreign)]
 pub trait ReceiverPersister: Send + Sync {
-    fn save(&self, receiver: Arc<Receiver>) -> Result<ReceiverToken, ImplementationError>;
-    fn load(&self, token: Arc<ReceiverToken>) -> Result<Receiver, ImplementationError>;
+    fn save(&self, receiver: Arc<Receiver>) -> Result<Arc<ReceiverToken>, PersistenceError>;
+    fn load(&self, token: Arc<ReceiverToken>) -> Result<Arc<Receiver>, PersistenceError>;
 }
 
 /// Adapter for the ReceiverPersister trait to use the save and load callbacks.
@@ -501,17 +515,18 @@ impl CallbackPersisterAdapter {
 
 impl payjoin::persist::Persister<payjoin::receive::v2::Receiver> for CallbackPersisterAdapter {
     type Token = ReceiverToken;
-    type Error = ImplementationError;
+    type Error = PersistenceError;
 
     fn save(
         &mut self,
         receiver: payjoin::receive::v2::Receiver,
     ) -> Result<Self::Token, Self::Error> {
         let receiver = Receiver(super::Receiver::from(receiver));
-        self.callback_persister.save(receiver.into())
+        let res = self.callback_persister.save(receiver.into())?;
+        Ok((*res).clone())
     }
 
     fn load(&self, token: Self::Token) -> Result<payjoin::receive::v2::Receiver, Self::Error> {
-        self.callback_persister.load(token.into()).map(|receiver| receiver.0 .0)
+        self.callback_persister.load(token.into()).map(|receiver| (*receiver).clone().0 .0)
     }
 }

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -112,7 +112,10 @@ impl Receiver {
         token: Arc<ReceiverToken>,
         persister: Arc<dyn ReceiverPersister>,
     ) -> Result<Self, ImplementationError> {
-        Ok(super::Receiver::from((*persister.load(token).unwrap()).clone()).into())
+        Ok(super::Receiver::from(
+            (*persister.load(token).map_err(|e| ImplementationError::from(e.to_string()))?).clone(),
+        )
+        .into())
     }
 
     /// The contents of the `&pj=` query parameter including the base64url-encoded public key receiver subdirectory.

--- a/src/send/uni.rs
+++ b/src/send/uni.rs
@@ -134,7 +134,10 @@ impl Sender {
         token: Arc<SenderToken>,
         persister: Arc<dyn SenderPersister>,
     ) -> Result<Self, ImplementationError> {
-        Ok(super::Sender::from((*persister.load(token).unwrap()).clone()).into())
+        Ok(super::Sender::from(
+            (*persister.load(token).map_err(|e| ImplementationError::from(e.to_string()))?).clone(),
+        )
+        .into())
     }
 
     pub fn extract_v1(&self) -> RequestV1Context {


### PR DESCRIPTION
This PR was originally created to add test coverage for the Sender/Receiver persistence methods. However upon writing the tests I noticed a couple things missing
* No load method for the uniffi exported sender
* No proper error handling when loading sender and receiver sessions
* Persistence traits need to be exposed with_foreign in order for persistence methods to be overridden 


Replacing https://github.com/LtbLightning/payjoin-ffi/pull/83