### PR TITLE
Create local lint.sh file

### DIFF
--- a/contrib/lint.sh
+++ b/contrib/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+# Run clippy at top level for crates without feature-specific checks
+echo "Running workspace lint..."
+cargo +nightly clippy --all-targets --keep-going --all-features -- -D warnings

--- a/src/io.rs
+++ b/src/io.rs
@@ -11,7 +11,7 @@ pub mod error {
     }
     impl From<payjoin::io::Error> for IoError {
         fn from(value: payjoin::io::Error) -> Self {
-            IoError { message: format!("{:?}", value) }
+            IoError { message: format!("{value:?}") }
         }
     }
 }

--- a/src/ohttp.rs
+++ b/src/ohttp.rs
@@ -9,7 +9,7 @@ pub mod error {
     }
     impl From<ohttp::Error> for OhttpError {
         fn from(value: ohttp::Error) -> Self {
-            OhttpError { message: format!("{:?}", value) }
+            OhttpError { message: format!("{value:?}") }
         }
     }
 }

--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -348,10 +348,7 @@ impl WantsOutputs {
         &self,
         output_script: Arc<Script>,
     ) -> Result<Arc<WantsOutputs>, OutputSubstitutionError> {
-        self.0
-            .substitute_receiver_script(&output_script)
-            .map(|t| Arc::new(t.into()))
-            .map_err(Into::into)
+        self.0.substitute_receiver_script(&output_script).map(|t| Arc::new(t.into()))
     }
 }
 

--- a/src/send/uni.rs
+++ b/src/send/uni.rs
@@ -28,7 +28,7 @@ impl SenderBuilder {
     /// to create a [`Sender`]
     #[uniffi::constructor]
     pub fn new(psbt: String, uri: Arc<PjUri>) -> Result<Self, BuildSenderError> {
-        super::SenderBuilder::new(psbt, (*uri).clone()).map(Into::into).map_err(Into::into)
+        super::SenderBuilder::new(psbt, (*uri).clone()).map(Into::into)
     }
 
     /// Disable output substitution even if the receiver didn't.


### PR DESCRIPTION
We had a hard time getting the lint working locally with a standard cargo clippy command and as a result we should probably ensure that we all have a standardized way of linting the source in the repo.