### PR TITLE
Bump version 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.23.0]
+
+- Update to payjoin-0.23.0
+- Expose many error variants
+  ([#58](https://github.com/LtbLightning/payjoin-ffi/pull/58))
+  ([#71](https://github.com/LtbLightning/payjoin-ffi/pull/71))
+- Bind payjoin-test-utils ([#82](https://github.com/LtbLightning/payjoin-ffi/pull/82))
+- Depend on bitcoin-ffi @ 6b1d1315dff8696b5ffeb3e5669f308ade227749
+- Rename to payjoin-ffi from payjoin_ffi to match bitcoin-ffi
+
 ## [0.22.1]
 - Expose label and messge params on Uri. ([#44](https://github.com/LtbLightning/payjoin-ffi/pull/44))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "payjoin-ffi"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "base64 0.22.1",
  "bdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,34 +1980,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "payjoin-test-utils"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f239ed1431504cc4efb8469e0986656d3741b5c2f810d9eef8de06e329a67e37"
-dependencies = [
- "bitcoin 0.32.5",
- "bitcoin-ohttp",
- "bitcoincore-rpc",
- "bitcoind",
- "http",
- "log",
- "ohttp-relay 0.0.10",
- "once_cell",
- "payjoin",
- "payjoin-directory",
- "rcgen",
- "reqwest",
- "rustls 0.22.4",
- "testcontainers",
- "testcontainers-modules 0.3.7",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "payjoin_ffi"
+name = "payjoin-ffi"
 version = "0.22.1"
 dependencies = [
  "base64 0.22.1",
@@ -2031,6 +2004,33 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "uniffi",
+ "url",
+]
+
+[[package]]
+name = "payjoin-test-utils"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f239ed1431504cc4efb8469e0986656d3741b5c2f810d9eef8de06e329a67e37"
+dependencies = [
+ "bitcoin 0.32.5",
+ "bitcoin-ohttp",
+ "bitcoincore-rpc",
+ "bitcoind",
+ "http",
+ "log",
+ "ohttp-relay 0.0.10",
+ "once_cell",
+ "payjoin",
+ "payjoin-directory",
+ "rcgen",
+ "reqwest",
+ "rustls 0.22.4",
+ "testcontainers",
+ "testcontainers-modules 0.3.7",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payjoin-ffi"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 exclude = ["tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "payjoin_ffi"
+name = "payjoin-ffi"
 version = "0.22.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We may need to wait for @0xBEEFCAF3 to fix a missing API element from send/uni.rs