### PR TITLE
Remove redundant uniffi feature flag

### DIFF
--- a/src/receive/uni.rs
+++ b/src/receive/uni.rs
@@ -160,7 +160,7 @@ impl Receiver {
     }
 }
 
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+#[derive(uniffi::Record)]
 pub struct RequestResponse {
     pub request: Request,
     pub client_response: Arc<ClientResponse>,


### PR DESCRIPTION
`src/receive/uni.rs` is already "uniffi" feature flagged.


cc @DanGould 